### PR TITLE
Fix bounding box computation & yoffset.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,7 @@ function generateImage (opt, callback) {
   contours.push(currentContour);
 
   let shapeDesc = '';
+  let firstCommand = true;
   contours.forEach(contour => {
     shapeDesc += '{';
     const lastIndex = contour.length - 1;
@@ -175,10 +176,18 @@ function generateImage (opt, callback) {
           shapeDesc += `(${command.x1}, ${command.y1}); `;
         }
         shapeDesc += `${command.x}, ${command.y}`;
-        bBox.left = Math.min(bBox.left, command.x);
-        bBox.bottom = Math.min(bBox.bottom, command.y);
-        bBox.right = Math.max(bBox.right, command.x);
-        bBox.top = Math.max(bBox.top, command.y);
+        if (firstCommand) {
+          bBox.left = command.x;
+          bBox.bottom = command.y;
+          bBox.right = command.x;
+          bBox.top = command.y;
+          firstCommand = false;
+        } else {
+          bBox.left = Math.min(bBox.left, command.x);
+          bBox.bottom = Math.min(bBox.bottom, command.y);
+          bBox.right = Math.max(bBox.right, command.x);
+          bBox.top = Math.max(bBox.top, command.y);
+        }
       }
       if (index !== lastIndex) {
         shapeDesc += '; ';
@@ -188,6 +197,7 @@ function generateImage (opt, callback) {
   });
   if (contours.some(cont => cont.length === 1)) console.log('length is 1, failed to normalize glyph');
   const scale = fontSize / font.unitsPerEm;
+  const baseline = font.ascender * (fontSize / font.unitsPerEm);
   const pad = 5;
   let width = Math.round(bBox.right - bBox.left) + pad + pad;
   let height = Math.round(bBox.top - bBox.bottom) + pad + pad;
@@ -232,7 +242,7 @@ function generateImage (opt, callback) {
           width: width,
           height: height,
           xoffset: 0,
-          yoffset: bBox.bottom,
+          yoffset: bBox.bottom - pad + baseline,
           xadvance: glyph.advanceWidth * scale,
           chnl: 15
         }


### PR DESCRIPTION
The bounding box calculations assumed that 0,0 was always inside the
bounding box, which is not the case for all glyphs.

The yoffset computation failed to account for the gap and for the fact
that fonts are rendered from the baseline up.

Here's Roboto generated before the fix and viewed in the layout-bmfont-text demo renderer:

<img width="814" alt="broken" src="https://user-images.githubusercontent.com/196340/28028867-cc742ce2-6552-11e7-89a7-8111d25f44a4.png">

Here's Roboto generated after the fix and viewed via the same code:

<img width="804" alt="fixed" src="https://user-images.githubusercontent.com/196340/28028877-d86d5546-6552-11e7-9149-ea29e275e057.png">

This also fixes the use of the font with three-bmfont-text which uses the yoffset and thus was offsetting the fonts incorrectly and now offsets them correctly.