### PR TITLE
Upgrade canvas dependency to v2.6.1 - This fixes incompatibility with recent versions of node

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function generateBMFont (fontPath, opt, callback) {
   if (font.outlinesFormat !== 'truetype') {
     throw new TypeError('must specify a truetype font');
   }
-  const canvas = new Canvas(textureWidth, textureHeight);
+  const canvas = Canvas.createCanvas(textureWidth, textureHeight);
   const context = canvas.getContext('2d');
   const packer = new MultiBinPacker(textureWidth, textureHeight, texturePadding);
   const chars = [];

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "canvas": "^1.4.0",
+    "canvas": "^2.6.1",
     "map-limit": "0.0.1",
     "multi-bin-packer": "^1.1.3",
     "opentype.js": "^0.6.4"


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?**

This is a bugfix.

**Does this PR introduce a breaking change?**

No.

**Did you test your solution?**

I ran `npm test`. An MSDF image was successfully produced and written to the test folder.

## Problem Description

The version of canvas used in the current version of msdf-bmfont is incompatible with recent versions of node.

I encountered a similar error as was reported here, so I tried upgrading this package's version of canvas. It worked as hoped and now I am able to use msdf-bmfont.

https://github.com/Automattic/node-canvas/issues/1501#issuecomment-564344611

## Solution Description

The version of the canvas package dependency has been updated to a version that is compatible with recent versions of node.

## Side Effects, Risks, Impact

Node 6.x and lower will no longer be supported by this tool.

https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md#200

**Aditional comments:**

None.